### PR TITLE
Allow i18n of colander error messages

### DIFF
--- a/cornice/__init__.py
+++ b/cornice/__init__.py
@@ -36,6 +36,16 @@ def add_apidoc(config, pattern, func, service, **kwargs):
 
 def set_localizer_for_languages(event, available_languages,
                                 default_locale_name):
+    """
+    Sets the current locale based on the incoming Accept-Language header, if
+    present, and sets a localizer attribute on the request object based on
+    the current locale.
+
+    To be used as an event handler, this function needs to be partially applied
+    with the available_languages and default_locale_name arguments. The
+    resulting function will be an event handler which takes an event object as
+    its only argument.
+    """
     request = event.request
     if request.accept_language:
         accepted = request.accept_language

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -148,11 +148,13 @@ def validate_colander_schema(schema, request):
                         deserialized = attr.deserialize(serialized)
                 except Invalid as e:
                     # the struct is invalid
+                    translate = request.localizer.translate
+                    error_dict = e.asdict(translate=translate)
                     try:
                         request.errors.add(location, attr.name,
-                                           e.asdict()[attr.name])
+                                           error_dict[attr.name])
                     except KeyError:
-                        for k, v in e.asdict().items():
+                        for k, v in error_dict.items():
                             if k.startswith(attr.name):
                                 request.errors.add(location, k, v)
                 else:

--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -412,3 +412,9 @@ class TestErrorMessageTranslation(TestCase):
         self.assertErrorDescription(
             response,
             u'10 は最大値 3 を超過しています')
+
+    def test_no_language_settings(self):
+        response = self.post()
+        self.assertErrorDescription(
+            response,
+            u'10 is greater than maximum value 3')

--- a/cornice/tests/validationapp.py
+++ b/cornice/tests/validationapp.py
@@ -218,6 +218,6 @@ def includeme(config):
 
 
 def main(global_config, **settings):
-    config = Configurator(settings={})
+    config = Configurator(settings=settings)
     config.include(includeme)
     return CatchErrors(config.make_wsgi_app())

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -202,8 +202,8 @@ View-specific deserializers have priority over global content-type
 deserializers.
 
 To enable localization of Colander error messages, you must set
-`available_languages <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/i18n.html#detecting-available-languages>`_ in your settings.
-You may also set `pyramid.default_locale_name <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/environment.html#default-locale-name-setting>`_.
+`available_languages <http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/i18n.html#detecting-available-languages>`_ in your settings.
+You may also set `pyramid.default_locale_name <http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/environment.html#default-locale-name-setting>`_.
 
 
 Using formencode

--- a/docs/source/validation.rst
+++ b/docs/source/validation.rst
@@ -201,6 +201,10 @@ before passing the result to Colander.
 View-specific deserializers have priority over global content-type
 deserializers.
 
+To enable localization of Colander error messages, you must set
+`available_languages <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/i18n.html#detecting-available-languages>`_ in your settings.
+You may also set `pyramid.default_locale_name <http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/environment.html#default-locale-name-setting>`_.
+
 
 Using formencode
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fix #200

After investigating the issue further, I realized that not everything can be done by Colander. Colander can only provide translation strings but it cannot perform the translation itself because it doesn't depend on Pyramid and doesn't know about localizers. As suggested earlier, I've proposed a change to Colander so that we can pass a translation callable to the ``asdict`` method: https://github.com/Pylons/colander/pull/157

However it's still up to Cornice to provide a callback that is aware of the current locale.
Since Cornice aims at following HTTP conventions, I've added support for the HTTP ``Accept-Language`` header. I've also added some configuration code that sets up a localizer depending on configuration variables based on suggestions from the Pyramid documentation:
 * [``pyramid.default_locale_name``](http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/i18n.html#localization-related-deployment-settings) to specify the default locale
 * [``available_languages``](http://docs.pylonsproject.org/projects/pyramid/en/1.3-branch/narr/i18n.html#detecting-available-languages) to specify the list of available languages