### PR TITLE
Set cors headers when a response is returned or exception is raised

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -498,7 +498,6 @@ def decorate_view(view, args, method):
         elif hasattr(ob, 'schema'):
             validate_colander_schema(ob.schema, request)
 
-
         # the validators can either be a list of callables or contain some
         # non-callable values. In which case we want to resolve them using the
         # object if any
@@ -507,7 +506,6 @@ def decorate_view(view, args, method):
             if is_string(validator) and ob is not None:
                 validator = getattr(ob, validator)
             validator(request)
-
 
         # only call the view if we don't have validation errors
         if len(request.errors) == 0:

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from pyramid import testing
-from pyramid.exceptions import NotFound
+from pyramid.exceptions import NotFound, HTTPBadRequest
 from pyramid.response import Response
 
 from webtest import TestApp
@@ -74,6 +74,14 @@ def get_some_bacon(request):
     if request.matchdict['type'] != 'good':
         raise NotFound(detail='Not. Found.')
     return "yay"
+
+@bacon.post()
+def post_some_bacon(request):
+    return Response()
+
+@bacon.put()
+def put_some_bacon(request):
+    raise HTTPBadRequest()
 
 from pyramid.view import view_config
 
@@ -272,6 +280,16 @@ class TestCORS(TestCase):
 
     def test_404_returns_CORS_headers(self):
         resp = self.app.get('/bacon/notgood', status=404,
+                            headers={'Origin': 'notmyidea.org'})
+        self.assertIn('Access-Control-Allow-Origin', resp.headers)
+
+    def test_response_returns_CORS_headers(self):
+        resp = self.app.post('/bacon/response', status=200,
+                            headers={'Origin': 'notmyidea.org'})
+        self.assertIn('Access-Control-Allow-Origin', resp.headers)
+
+    def test_raise_returns_CORS_headers(self):
+        resp = self.app.put('/bacon/raise', status=400,
                             headers={'Origin': 'notmyidea.org'})
         self.assertIn('Access-Control-Allow-Origin', resp.headers)
 


### PR DESCRIPTION
When a view raises an exception or returns a Response object, cors allow-origin headers are not set. This PR makes sure the headers are set.