### PR TITLE
Empty response to OPTIONS request

### DIFF
--- a/cornice/validators.py
+++ b/cornice/validators.py
@@ -1,22 +1,5 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
-import re
-
-# Strings and arrays are potentially exploitable
-safe_json_re = re.compile(r'\s*[\{tfn\-0-9]'.encode('ascii'), re.MULTILINE)
-
-
-def filter_json_xsrf(response):
-    """drops a warning if a service returns potentially exploitable json
-    """
-    if hasattr(response, 'content_type') and response.content_type in ('application/json', 'text/json'):
-        if safe_json_re.match(response.body) is None:
-            from cornice import logger
-            logger.warn("returning a json string or array is a potential "
-                "security hole, please ensure you really want to do this.")
-    return response
-
-
 DEFAULT_VALIDATORS = []
-DEFAULT_FILTERS = [filter_json_xsrf, ]
+DEFAULT_FILTERS = []

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py33
+envlist = py26,py27,py34
 
 [testenv]
 commands =


### PR DESCRIPTION
While using angular to make POST request I've noticed a warning:

> 2014-10-12 21:28:12,091 WARNI [cornice][Dummy-2] returning a json string or array is a potential security hole, please ensure you really want to do this.

After some investigation I realised that this is because response to OPTIONS request had an empty body `b'""'`. If I'm not mistaken, angular makes this request before POSTing data. Would it be better if cornice(?) returned an empty object `{}`?

To replicate this warning define any resource. Add `cors_origins=('*',)` option, and then make a call, for example, with `curl`:

> curl -X OPTIONS -H "Origin:http://localhost:6543/" -H "Access-Control-Request-Method:OPTIONS" localhost:6543/api/v1/notes

And you'll get a warning from cornice.