### PR TITLE
When using set_default_permissions OPTIONS calls for CORS does not work anymore.

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -159,7 +159,8 @@ def register_service_views(config, service):
     # before doing anything else, register a view for the OPTIONS method
     # if we need to
     if service.cors_enabled and 'OPTIONS' not in service.defined_methods:
-        service.add_view('options', view=get_cors_preflight_view(service))
+        service.add_view('options', view=get_cors_preflight_view(service),
+                         permission=NO_PERMISSION_REQUIRED)
 
     # register the fallback view, which takes care of returning good error
     # messages to the user-agent

--- a/cornice/tests/ext/test_spore.py
+++ b/cornice/tests/ext/test_spore.py
@@ -48,7 +48,7 @@ class TestSporeGeneration(TestCase):
             'path': '/coffee',
             'method': 'GET',
             'formats': ['json'],
-            })
+        })
 
         self.assertIn('post_coffees', methods)
         self.assertDictEqual(methods['post_coffees'], {
@@ -56,7 +56,7 @@ class TestSporeGeneration(TestCase):
             'method': 'POST',
             'formats': ['json'],
             'description': post_coffees.__doc__
-            })
+        })
 
         self.assertIn('get_coffee', methods)
         self.assertDictEqual(methods['get_coffee'], {
@@ -64,7 +64,7 @@ class TestSporeGeneration(TestCase):
             'method': 'GET',
             'formats': ['json'],
             'required_params': ['bar', 'id']
-            })
+        })
 
     def test_rxjson_spore(self):
         rx = Rx.Factory({'register_core_types': True})

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -62,7 +62,7 @@ def gimme_some_spam_please(request):
     return 'spam'
 
 
-@spam.post(permission="read-only")
+@spam.post(permission='read-only')
 def moar_spam(request):
     return 'moar spam'
 
@@ -99,9 +99,9 @@ class TestCORS(TestCase):
 
     def setUp(self):
         self.config = testing.setUp()
-        self.config.include("cornice")
+        self.config.include('cornice')
         self.config.add_route('noservice', '/noservice')
-        self.config.scan("cornice.tests.test_cors")
+        self.config.scan('cornice.tests.test_cors')
         self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
 
     def tearDown(self):
@@ -316,7 +316,7 @@ class TestCORS(TestCase):
         self.assertEqual(resp.body, b'No Service here.')
 
 
-class TestAuthenticatedCors(TestCase):
+class TestAuthenticatedCORS(TestCase):
     def setUp(self):
 
         def check_cred(username, *args, **kwargs):
@@ -328,13 +328,13 @@ class TestAuthenticatedCors(TestCase):
                 return permission in principals
 
         self.config = testing.setUp()
-        self.config.include("cornice")
+        self.config.include('cornice')
         self.config.add_route('noservice', '/noservice')
         self.config.set_authorization_policy(AuthorizationPolicy())
         self.config.set_authentication_policy(BasicAuthAuthenticationPolicy(
             check_cred))
         self.config.set_default_permission('readwrite')
-        self.config.scan("cornice.tests.test_cors")
+        self.config.scan('cornice.tests.test_cors')
         self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
 
     def tearDown(self):

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -2,9 +2,12 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
 from pyramid import testing
+from pyramid.authentication import BasicAuthAuthenticationPolicy
 from pyramid.exceptions import NotFound, HTTPBadRequest
+from pyramid.interfaces import IAuthorizationPolicy
 from pyramid.response import Response
 from pyramid.view import view_config
+from zope.interface import implementer
 
 from webtest import TestApp
 
@@ -59,7 +62,7 @@ def gimme_some_spam_please(request):
     return 'spam'
 
 
-@spam.post()
+@spam.post(permission="read-only")
 def moar_spam(request):
     return 'moar spam'
 
@@ -98,12 +101,11 @@ class TestCORS(TestCase):
         self.config = testing.setUp()
         self.config.include("cornice")
         self.config.add_route('noservice', '/noservice')
-
         self.config.scan("cornice.tests.test_cors")
         self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
 
-        def tearDown(self):
-            testing.tearDown()
+    def tearDown(self):
+        testing.tearDown()
 
     def test_preflight_cors_klass_post(self):
         resp = self.app.options('/cors_klass',
@@ -312,3 +314,36 @@ class TestCORS(TestCase):
         resp = self.app.get('/noservice', status=200,
                             headers={'Origin': 'notmyidea.org'})
         self.assertEqual(resp.body, b'No Service here.')
+
+
+class TestAuthenticatedCors(TestCase):
+    def setUp(self):
+
+        def check_cred(username, *args, **kwargs):
+            return [username]
+
+        @implementer(IAuthorizationPolicy)
+        class AuthorizationPolicy(object):
+            def permits(self, context, principals, permission):
+                return permission in principals
+
+        self.config = testing.setUp()
+        self.config.include("cornice")
+        self.config.add_route('noservice', '/noservice')
+        self.config.set_authorization_policy(AuthorizationPolicy())
+        self.config.set_authentication_policy(BasicAuthAuthenticationPolicy(
+            check_cred))
+        self.config.set_default_permission('readwrite')
+        self.config.scan("cornice.tests.test_cors")
+        self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
+
+    def tearDown(self):
+        testing.tearDown()
+
+    def test_post_on_spam_should_be_forbidden(self):
+        self.app.post('/spam', status=403)
+
+    def test_preflight_does_not_need_authentication(self):
+        self.app.options('/spam', status=200,
+                         headers={'Origin': 'notmyidea.org',
+                                  'Access-Control-Request-Method': 'POST'})


### PR DESCRIPTION
Because browser doesn't send Authorization headers on OPTIONS call.