### PR TITLE
Safety check on CORS methods in Service

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -460,7 +460,7 @@ class Service(object):
             The method to check the credentials support for
         """
         for meth, view, args in self.definitions:
-            if meth.upper() == method.upper():
+            if method and meth.upper() == method.upper():
                 return args.get('cors_credentials', False)
 
         if getattr(self, 'cors_credentials', False):
@@ -469,7 +469,7 @@ class Service(object):
 
     def cors_max_age_for(self, method=None):
         for meth, view, args in self.definitions:
-            if meth.upper() == method.upper():
+            if method and meth.upper() == method.upper():
                 return args.get('cors_max_age', False)
 
         return getattr(self, 'cors_max_age', None)

--- a/cornice/tests/test_service.py
+++ b/cornice/tests/test_service.py
@@ -420,10 +420,12 @@ class TestService(TestCase):
 
     def test_credential_support_can_be_enabled(self):
         foo = Service(name='foo', path='/foo', cors_credentials=True)
+        foo.add_view('POST', _stub)
         self.assertTrue(foo.cors_support_credentials())
 
     def test_credential_support_is_disabled_by_default(self):
         foo = Service(name='foo', path='/foo')
+        foo.add_view('POST', _stub)
         self.assertFalse(foo.cors_support_credentials())
 
     def test_per_method_credential_support(self):
@@ -440,6 +442,7 @@ class TestService(TestCase):
 
     def test_max_age_can_be_defined(self):
         foo = Service(name='foo', path='/foo', cors_max_age=42)
+        foo.add_view('POST', _stub)
         self.assertEqual(foo.cors_max_age_for(), 42)
 
     def test_max_age_can_be_different_dependeing_methods(self):


### PR DESCRIPTION
Fix crash with ``Service.cors_max_age_for()`` and ``Service.cors_support_credentials()``