### PR TITLE
"Simply" is redundant and well, not accurate.

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -135,7 +135,7 @@ to add our first service - the users management ::
 
 What we have here is 3 methods on **/users**:
 
-- **GET**: return the list of users names -- the keys of _USERS
+- **GET**: returns the list of users names -- the keys of _USERS
 - **POST**: adds a new user and returns a unique token
 - **DELETE**: removes the user.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -135,7 +135,7 @@ to add our first service - the users management ::
 
 What we have here is 3 methods on **/users**:
 
-- **GET**: simply return the list of users names -- the keys of _USERS
+- **GET**: return the list of users names -- the keys of _USERS
 - **POST**: adds a new user and returns a unique token
 - **DELETE**: removes the user.
 


### PR DESCRIPTION
I believe we should strike "simply", "easily", and "obviously" from all tutorials or presentations.  :-)  I'm working through cornice now and just thought I'd provide a tad of cleanup.