### PR TITLE
Fix #264

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -170,6 +170,8 @@ def register_service_views(config, service):
     cornice_parameters = ('filters', 'validators', 'schema', 'klass',
                           'error_handler', 'deserializer') + CORS_PARAMETERS
 
+    route_added = False
+
     for method, view, args in service.definitions:
 
         args = copy.copy(args)  # make a copy of the dict to not modify it
@@ -191,6 +193,7 @@ def register_service_views(config, service):
             if item in args:
                 del args[item]
 
+    
         # if acl is present, then convert it to a "factory"
         if 'acl' in args:
             args["factory"] = make_route_factory(args.pop('acl'))
@@ -203,7 +206,9 @@ def register_service_views(config, service):
         if 'traverse' in args:
             route_args['traverse'] = args.pop('traverse')
 
-        config.add_route(route_name, service.path, **route_args)
+        if not route_added:
+            config.add_route(route_name, service.path, **route_args)
+            route_added = True
 
         # 2. register view(s)
         # pop and compute predicates which get passed through to Pyramid 1:1

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -170,7 +170,22 @@ def register_service_views(config, service):
     cornice_parameters = ('filters', 'validators', 'schema', 'klass',
                           'error_handler', 'deserializer') + CORS_PARAMETERS
 
-    route_added = False
+    # 1. register route
+
+    route_args = {}
+
+    if hasattr(service, 'acl'):
+        route_args['factory'] = make_route_factory(service.acl)
+
+    elif hasattr(service, 'factory'):
+        route_args['factory'] = service.factory
+
+    if hasattr(service, 'traverse'):
+        route_args['traverse'] = service.traverse
+
+    config.add_route(route_name, service.path, **route_args)
+
+    # 2. register view(s)
 
     for method, view, args in service.definitions:
 
@@ -193,24 +208,12 @@ def register_service_views(config, service):
             if item in args:
                 del args[item]
 
-    
-        # if acl is present, then convert it to a "factory"
-        if 'acl' in args:
-            args["factory"] = make_route_factory(args.pop('acl'))
+        # These attributes are used in routes not views
+        deprecated_attrs = ['acl', 'factory', 'traverse']
+        for attr in deprecated_attrs:
+            if attr in args:
+                args.pop(attr)
 
-        # 1. register route
-        route_args = {}
-        if 'factory' in args:
-            route_args['factory'] = args.pop('factory')
-
-        if 'traverse' in args:
-            route_args['traverse'] = args.pop('traverse')
-
-        if not route_added:
-            config.add_route(route_name, service.path, **route_args)
-            route_added = True
-
-        # 2. register view(s)
         # pop and compute predicates which get passed through to Pyramid 1:1
 
         predicate_definitions = _pop_complex_predicates(args)

--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -26,7 +26,7 @@ def resource(depth=1, **kw):
         services = {}
 
         if 'collection_path' in kw:
-            prefixes = ('collection_', '')
+            prefixes = ('', 'collection_')
         else:
             prefixes = ('',)
 
@@ -41,8 +41,8 @@ def resource(depth=1, **kw):
                 elif k not in service_args:
                     service_args[k] = kw[k]
 
-            if prefix == 'collection_' and 'collection_acl' in kw.keys():
-                kw['acl'] = kw['collection_acl']
+            if prefix == 'collection_' and 'collection_acl' in service_args.keys():
+                service_args['acl'] = service_args['collection_acl']
 
             # create service
             service_name = (service_args.pop('name', None) or

--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -41,6 +41,9 @@ def resource(depth=1, **kw):
                 elif k not in service_args:
                     service_args[k] = kw[k]
 
+            if prefix == 'collection_' and 'collection_acl' in kw.keys():
+                kw['acl'] = kw['collection_acl']
+
             # create service
             service_name = (service_args.pop('name', None) or
                             klass.__name__.lower())

--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -41,7 +41,7 @@ def resource(depth=1, **kw):
                 elif k not in service_args:
                     service_args[k] = kw[k]
 
-            if prefix == 'collection_' and 'collection_acl' in service_args.keys():
+            if prefix == 'collection_' and service_args.get('collection_acl'):
                 service_args['acl'] = service_args['collection_acl']
 
             # create service

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -290,20 +290,20 @@ class Service(object):
 
         if 'acl' in kwargs:
             kwargs.pop('acl')
-            msg = "Warning: Using acl in method definitions is deprecated." +\
-                "Use service or resource instead."
+            msg = ("Warning: Using acl in method definitions is deprecated."
+                   "Use service or resource instead.")
             warnings.warn(msg, DeprecationWarning)
 
         if 'factory' in kwargs:
             kwargs.pop('factory')
-            msg = "Warning: Using acl in method definitions is deprecated." +\
-                "Use service or resource instead."
+            msg = ("Warning: Using acl in method definitions is deprecated."
+                   "Use service or resource instead.")
             warnings.warn(msg, DeprecationWarning)
 
         if 'traverse' in kwargs:
             kwargs.pop('traverse')
-            msg = "Warning: Using traverse in method definitions is deprecated." +\
-                "Use service or resource instead."
+            msg = ("Warning: Using traverse in method definitions is "
+                   "deprecated. Use service or resource instead.")
             warnings.warn(msg, DeprecationWarning)
 
         method = method.upper()

--- a/cornice/service.py
+++ b/cornice/service.py
@@ -287,6 +287,25 @@ class Service(object):
         :param **kwargs: additional configuration for this view,
                         including `permission`.
         """
+
+        if 'acl' in kwargs:
+            kwargs.pop('acl')
+            msg = "Warning: Using acl in method definitions is deprecated." +\
+                "Use service or resource instead."
+            warnings.warn(msg, DeprecationWarning)
+
+        if 'factory' in kwargs:
+            kwargs.pop('factory')
+            msg = "Warning: Using acl in method definitions is deprecated." +\
+                "Use service or resource instead."
+            warnings.warn(msg, DeprecationWarning)
+
+        if 'traverse' in kwargs:
+            kwargs.pop('traverse')
+            msg = "Warning: Using traverse in method definitions is deprecated." +\
+                "Use service or resource instead."
+            warnings.warn(msg, DeprecationWarning)
+
         method = method.upper()
         if 'schema' in kwargs:
             # this is deprecated and unusable because multiple schema

--- a/cornice/tests/test_pyramidhook.py
+++ b/cornice/tests/test_pyramidhook.py
@@ -29,14 +29,6 @@ from cornice.util import func_name
 
 from mock import MagicMock
 
-service = Service(name="service", path="/service")
-
-
-@service.get()
-def return_404(request):
-    raise HTTPNotFound()
-
-
 def my_acl(request):
     return [(Allow, 'alice', 'read'),
             (Allow, 'bob', 'write'),
@@ -44,13 +36,19 @@ def my_acl(request):
             (Allow, 'dan', ('write', 'update')),
         ]
 
+service = Service(name="service", path="/service", acl=my_acl)
 
-@service.put(acl=my_acl, permission='update')
+
+@service.get()
+def return_404(request):
+    raise HTTPNotFound()
+
+@service.put(permission='update')
 def update_view(request):
     return "updated_view"
 
 
-@service.delete(acl=my_acl, permission='write')
+@service.delete(permission='write')
 def return_yay(request):
     return "yay"
 

--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -23,6 +23,7 @@ from cornice.tests.support import dummy_factory
 
 USERS = {1: {'name': 'gawel'}, 2: {'name': 'tarek'}}
 
+
 def my_collection_acl(request):
     return [(Allow, 'alice', 'read')]
 

--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -4,7 +4,14 @@
 import json
 
 from pyramid import testing
+from pyramid.authentication import AuthTktAuthenticationPolicy
+from pyramid.authorization import ACLAuthorizationPolicy
+from pyramid.security import Allow
+from pyramid.httpexceptions import (
+    HTTPOk, HTTPForbidden, HTTPNotFound, HTTPMethodNotAllowed
+)
 from webtest import TestApp
+import mock
 
 from cornice.resource import resource
 from cornice.resource import view
@@ -15,6 +22,21 @@ from cornice.tests.support import dummy_factory
 
 
 USERS = {1: {'name': 'gawel'}, 2: {'name': 'tarek'}}
+
+def my_collection_acl(request):
+    return [(Allow, 'alice', 'read')]
+
+@resource(collection_path='/thing', path='/thing/{id}',
+          name='thing_service', collection_acl=my_collection_acl)
+class Thing(object):
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    @view(permission='read')
+    def collection_get(self):
+        return 'yay'
 
 
 @resource(collection_path='/users', path='/users/{id}',
@@ -54,6 +76,11 @@ class TestResource(TestCase):
         self.config = testing.setUp()
         self.config.add_renderer('jsonp', JSONP(param_name='callback'))
         self.config.include("cornice")
+        self.authz_policy = ACLAuthorizationPolicy()
+        self.config.set_authorization_policy(self.authz_policy)
+
+        self.authn_policy = AuthTktAuthenticationPolicy('$3kr1t')
+        self.config.set_authentication_policy(self.authn_policy)
         self.config.scan("cornice.tests.test_resource")
         self.app = TestApp(CatchErrors(self.config.make_wsgi_app()))
 
@@ -109,6 +136,17 @@ class TestResource(TestCase):
     def test_explicit_service_name(self):
         route_url = testing.DummyRequest().route_url
         self.assert_(route_url('user_service', id=42))  # service must exist
+
+    def test_acl_support_unauthenticated_thing_get(self):
+        # calling a view with permissions without an auth'd user => 403
+        self.app.get('/thing', status=HTTPForbidden.code)
+
+    def test_acl_support_authenticated_allowed_thing_get(self):
+        with mock.patch.object(self.authn_policy, 'unauthenticated_userid',
+                               return_value='alice'):
+            result = self.app.get('/thing', status=HTTPOk.code)
+            self.assertEqual("yay", result.json)
+
 
     if validationapp.COLANDER:
         def test_schema_on_resource(self):

--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -148,7 +148,6 @@ class TestResource(TestCase):
             result = self.app.get('/thing', status=HTTPOk.code)
             self.assertEqual("yay", result.json)
 
-
     if validationapp.COLANDER:
         def test_schema_on_resource(self):
             User.schema = CorniceSchema.from_colander(

--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -8,7 +8,7 @@ from pyramid.authentication import AuthTktAuthenticationPolicy
 from pyramid.authorization import ACLAuthorizationPolicy
 from pyramid.security import Allow
 from pyramid.httpexceptions import (
-    HTTPOk, HTTPForbidden, HTTPNotFound, HTTPMethodNotAllowed
+    HTTPOk, HTTPForbidden
 )
 from webtest import TestApp
 import mock
@@ -25,6 +25,7 @@ USERS = {1: {'name': 'gawel'}, 2: {'name': 'tarek'}}
 
 def my_collection_acl(request):
     return [(Allow, 'alice', 'read')]
+
 
 @resource(collection_path='/thing', path='/thing/{id}',
           name='thing_service', collection_acl=my_collection_acl)


### PR DESCRIPTION
This fixes #264. The issue was that the route for a service is added once for each method. Each time the original route is overridden with a new root factory. The default options method has no ACL attached so it ends up overwriting the route with a root factory with no ACL. The way routes are added needs to be rethought. This is fixes the problem for the interim but the order in which routes are added could still result in issues.