### PR TITLE
Allow arbitrary path prefixes in Cornice resource.

### DIFF
--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -18,41 +18,43 @@ def resource(depth=1, **kw):
     will be used as such. You can also prefix them by "collection_" and they
     will be treated as HTTP methods for the given collection path
     (collection_path), if any.
-    
+
     Here is an example::
 
         @resource(collection_path='/users', path='/users/{id}')
-        
+
     You can also add any other prefixed path like e.g. "activate_path".
     This may be useful when defining sub-resources.
 
     Here is an example::
 
-        @resource(collection_path='/users', path='/users/{id}', 
+        @resource(collection_path='/users', path='/users/{id}',
                   activate_path='/users/{id}/activate')
     """
     def wrapper(klass):
         services = {}
 
-        path_keys = [x[:len(x)-len('path')] for x in list(kw) if x.endswith('_path')]
+        path_keys = [x[:len(x)-len('path')] for x in list(kw)
+                     if x.endswith('_path')]
         if len(path_keys) > 0:
             prefixes = tuple(path_keys + [''])
         else:
             prefixes = ('',)
-        
+
         def filter_prefixes(prefix, x):
             """Filters out keys for prefixes other than specified prefix.
             """
             other = set(prefixes) - set(['', prefix])
             return len([y for y in other if x.startswith(y)]) == 0
-        
+
         for prefix in prefixes:
 
             # get clean view arguments
             service_args = {}
-            
-            filter_other = filter(functools.partial(filter_prefixes, prefix), list(kw))
-            
+
+            filter_other = filter(functools.partial(filter_prefixes, prefix),
+                                  list(kw))
+
             for k in filter_other:
                 if k.startswith(prefix):
                     service_args[k[len(prefix):]] = kw[k]

--- a/cornice/resource.py
+++ b/cornice/resource.py
@@ -8,6 +8,7 @@ try:
     VENUSIAN = True
 except ImportError:
     VENUSIAN = False
+import functools
 
 
 def resource(depth=1, **kw):
@@ -17,32 +18,51 @@ def resource(depth=1, **kw):
     will be used as such. You can also prefix them by "collection_" and they
     will be treated as HTTP methods for the given collection path
     (collection_path), if any.
-
+    
     Here is an example::
 
         @resource(collection_path='/users', path='/users/{id}')
+        
+    You can also add any other prefixed path like e.g. "activate_path".
+    This may be useful when defining sub-resources.
+
+    Here is an example::
+
+        @resource(collection_path='/users', path='/users/{id}', 
+                  activate_path='/users/{id}/activate')
     """
     def wrapper(klass):
         services = {}
 
-        if 'collection_path' in kw:
-            prefixes = ('', 'collection_')
+        path_keys = [x[:len(x)-len('path')] for x in list(kw) if x.endswith('_path')]
+        if len(path_keys) > 0:
+            prefixes = tuple(path_keys + [''])
         else:
             prefixes = ('',)
-
+        
+        def filter_prefixes(prefix, x):
+            """Filters out keys for prefixes other than specified prefix.
+            """
+            other = set(prefixes) - set(['', prefix])
+            return len([y for y in other if x.startswith(y)]) == 0
+        
         for prefix in prefixes:
 
             # get clean view arguments
             service_args = {}
-            for k in list(kw):
-                if k.startswith('collection_'):
-                    if prefix == 'collection_':
-                        service_args[k[len(prefix):]] = kw[k]
+            
+            filter_other = filter(functools.partial(filter_prefixes, prefix), list(kw))
+            
+            for k in filter_other:
+                if k.startswith(prefix):
+                    service_args[k[len(prefix):]] = kw[k]
                 elif k not in service_args:
                     service_args[k] = kw[k]
 
-            if prefix == 'collection_' and service_args.get('collection_acl'):
-                service_args['acl'] = service_args['collection_acl']
+            if prefix != '':
+                prefix_acl = prefix + '_acl'
+                if service_args.get(prefix_acl):
+                    service_args['acl'] = service_args[prefix_acl]
 
             # create service
             service_name = (service_args.pop('name', None) or


### PR DESCRIPTION
This pull request allows arbitrary path prefixes in Cornice **resource**. It can be very useful for grouping related methods, sub-resources, etc. Changes to **resource** decorator drop the notion of having only *path* and *collection_path* and allows for any number of prefixed paths. 

For example if you want to create sub-resource for *users* collection that will allow for example issuing methods or manipulating depended collections (like e.g. *friends*) you can create a resource like this:
@resource(collection_path='/users', path='/users/{id}', friends_path='/users/{id}/friends', friend_path='/users/{id}/friends/{name}')
This is much cleaner than building another **resource** that has to utilize only *collection_path* and *path* and sometimes may be useful for defining actions on resource instance like e.g. '/users/{id}/activate'. I know that some say this is sometimes not very RESTful way of doing things, and should be done with path e.g. '/userActivate/{id}', but in my opinion allowing defining sub-resources and additional paths within the same class logically groups the code for closely related HTTP methods. 

This change shouldn't  in any way break existing code, but simply allows extending Cornice resource beyond what was possible until now.