### PR TITLE
Import reload for Python 3

### DIFF
--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -8,6 +8,10 @@ Sphinx extension that is able to convert a service into a documentation.
 import sys
 import json
 from importlib import import_module
+try:
+    from importlib import reload
+except ImportError:
+    pass
 
 from cornice.util import to_list, is_string, PY3
 from cornice.service import get_services, clear_services

--- a/cornice/tests/ext/test_sphinxext.py
+++ b/cornice/tests/ext/test_sphinxext.py
@@ -1,8 +1,10 @@
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this file,
 # You can obtain one at http://mozilla.org/MPL/2.0/.
+import mock
+
 from cornice.tests.support import TestCase
-from cornice.ext.sphinxext import rst2html
+from cornice.ext.sphinxext import rst2html, ServiceDirective
 
 
 class TestUtil(TestCase):
@@ -12,3 +14,13 @@ class TestUtil(TestCase):
         res = rst2html(text)
         self.assertEqual(res, b'<p><strong>simple render</strong></p>')
         self.assertEqual(rst2html(''), '')
+
+
+class TestServiceDirective(TestCase):
+
+    def test_module_reload(self):
+        directive = ServiceDirective(
+            'test', [], {}, [], 1, 1, 'test', mock.Mock(), 1)
+        directive.options['modules'] = ['cornice']
+        directive.run()
+        directive.run()


### PR DESCRIPTION
Python 3 does not have the `reload` built-in.  As of Python 3.4, `reload` is available in `importlib`, see
https://docs.python.org/3/library/importlib.html#importlib.reload.

A test is included that shows the breakage/fix.  I'll be happy to make any additional changes requested.