### PR TITLE
Fix schema typing

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -95,14 +95,14 @@ class CorniceSchema(object):
 
 def validate_colander_schema(schema, request):
     """Validates that the request is conform to the given schema"""
-    from colander import Invalid, Sequence, drop, null, MappingSchema
+    from colander import Invalid, Sequence, drop, null, Mapping
 
-    schema_type = schema.colander_schema.schema_type()
+    schema_type = schema.colander_schema.typ
     unknown = getattr(schema_type, 'unknown', None)
 
-    if not isinstance(schema.colander_schema, MappingSchema):
-        raise SchemaError('schema is not a MappingSchema: %s' %
-                          type(schema.colander_schema))
+    if not isinstance(schema_type, Mapping):
+        raise SchemaError('colander schema type is not a Mapping: %s' %
+                          type(schema_type))
 
     def _validate_fields(location, data):
         if location == 'body':
@@ -167,7 +167,7 @@ def validate_colander_schema(schema, request):
     _validate_fields('querystring', qs)
 
     # validate unknown
-    if schema.colander_schema.typ.unknown == 'raise':
+    if unknown == 'raise':
         attrs = schema.get_attributes(location=('body', 'querystring'),
                                       request=request)
         params = list(qs.keys()) + list(body.keys())

--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -97,6 +97,9 @@ def validate_colander_schema(schema, request):
     """Validates that the request is conform to the given schema"""
     from colander import Invalid, Sequence, drop, null, Mapping
 
+    # CorniceSchema.colander_schema guarantees that we have a colander
+    #  instance and not a class so we should use `typ` and not
+    #  `schema_type()` to determine the type.
     schema_type = schema.colander_schema.typ
     unknown = getattr(schema_type, 'unknown', None)
 

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -14,6 +14,7 @@ try:
         deferred,
         Mapping,
         MappingSchema,
+        Sequence,
         SequenceSchema,
         SchemaNode,
         String,
@@ -229,6 +230,9 @@ if COLANDER:
             self.assertEqual(len(body_fields), 2)
             self.assertEqual(len(qs_fields), 1)
 
+            dummy_request = get_mock_request('{"bar": "some data"}')
+            validate_colander_schema(schema, dummy_request)
+
         def test_colander_schema_using_drop(self):
             """
             remove fields from validated data if they deserialize to colander's
@@ -343,6 +347,19 @@ if COLANDER:
             schema = CorniceSchema.from_colander(WrongSchema)
             dummy_request = get_mock_request('', {'foo': 'test',
                                                   'bar': 'test'})
+            self.assertRaises(SchemaError,
+                              validate_colander_schema, schema, dummy_request)
+
+            # We shouldn't accept a MappingSchema if the `typ` has
+            #  been set to something else:
+            schema = CorniceSchema.from_colander(
+                MappingSchema(
+                    Sequence,
+                    SchemaNode(String(), name='foo'),
+                    SchemaNode(String(), name='bar'),
+                    SchemaNode(String(), name='baz')
+                )
+            )
             self.assertRaises(SchemaError,
                               validate_colander_schema, schema, dummy_request)
 

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -66,7 +66,7 @@ if COLANDER:
     class StrictMappingSchema(MappingSchema):
         @staticmethod
         def schema_type():
-            return MappingSchema.schema_type(unknown='raise')
+            return Mapping(unknown='raise')
 
     class StrictSchema(StrictMappingSchema):
         foo = SchemaNode(String(), type='str', location="body", missing=drop)
@@ -110,7 +110,8 @@ if COLANDER:
     class PreserveUnkownSchema(MappingSchema):
         bar = SchemaNode(String(), type='str')
 
-        def schema_type(self, **kw):
+        @staticmethod
+        def schema_type():
             return Mapping(unknown='preserve')
 
     def get_mock_request(body, get=None):


### PR DESCRIPTION
fixes: #307

Unfortunately I didn't have the time to fully understand the code and try to do duck typing.  Right now it uses the `unknown` property that only really exists on the `Mapping` type.  The major thing is a SchemaNode(Mapping()) will now work.