### PR TITLE
make test less dependent on pyramid version

### DIFF
--- a/cornice/tests/test_resource.py
+++ b/cornice/tests/test_resource.py
@@ -104,19 +104,13 @@ class TestResource(TestCase):
         testing.tearDown()
 
     def test_basic_resource(self):
-        from pkg_resources import parse_version, get_distribution
-        current_version = parse_version(get_distribution('pyramid').version)
-
         self.assertEqual(self.app.get("/users").json, {'users': [1, 2]})
 
         self.assertEqual(self.app.get("/users/1").json, {'name': 'gawel'})
 
         resp = self.app.get("/users/1?callback=test")
 
-        if current_version < parse_version('1.5a4'):
-            self.assertEqual(resp.body, b'test({"name": "gawel"})', resp.body)
-        else:
-            self.assertEqual(resp.body, b'test({"name": "gawel"});', resp.body)
+        self.assertIn(b'test({"name": "gawel"})', resp.body, msg=resp.body)
 
     def test_accept_headers(self):
         # the accept headers should work even in case they're specified in a


### PR DESCRIPTION
Running my own tests I got a failure on `test_basic_resource` using py34 and pyramid==1.5.7.  The message I got was this:
```
======================================================================
FAIL: test_basic_resource (cornice.tests.test_resource.TestResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tim/cornice/cornice/tests/test_resource.py", line 119, in test_basic_resource
    self.assertEqual(resp.body, b'test({"name": "gawel"});', resp.body)
AssertionError: b'/**/test({"name": "gawel"});' != b'test({"name": "gawel"});' : b'/**/test({"name": "gawel"});'

----------------------------------------------------------------------
```

Instead of adding another branch on the if statement for that particular version, I changed the test to capture what we're really looking for...  It tests that the string contains 'test({"name": "gawel"})'.

I'm a little confused as to why tox fetches the alpha version of pyramid 1.6 instead of using the latest version found at https://pypi.python.org/pypi/pyramid (which is 1.5.7).  I guess because it's the most recent version found at https://pypi.python.org/simple/pyramid/ .