### PR TITLE
fix check for cors allow credentials

### DIFF
--- a/cornice/cors.py
+++ b/cornice/cors.py
@@ -96,8 +96,7 @@ def ensure_origin(service, request, response=None):
                         for o in service.cors_origins_for(method)]):
                 request.errors.add('header', 'Origin',
                                    '%s not allowed' % origin)
-            elif request.headers.get(
-                    'Access-Control-Allow-Credentials', False):
+            elif service.cors_support_credentials_for(method):
                 response.headers['Access-Control-Allow-Origin'] = origin
             else:
                 if any([o == "*" for o in service.cors_origins_for(method)]):

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -238,6 +238,8 @@ class TestCORS(TestCase):
             })
         self.assertEqual(resp.headers['Access-Control-Allow-Origin'],
                          'lolnet.org')
+        self.assertEqual(resp.headers['Access-Control-Allow-Credentials'],
+                         'true')
 
     def test_responses_include_an_allow_origin_header(self):
         resp = self.app.get('/squirel', headers={'Origin': 'notmyidea.org'})

--- a/cornice/tests/test_cors.py
+++ b/cornice/tests/test_cors.py
@@ -228,15 +228,6 @@ class TestCORS(TestCase):
         self.assertNotIn('Access-Control-Allow-Origin', resp.headers)
         self.assertEqual(resp.json, 'squirels')
 
-    def test_resp_allow_origin_wildcard(self):
-        resp = self.app.options(
-            '/cors_klass',
-            status=200,
-            headers={
-                'Origin': 'lolnet.org',
-                'Access-Control-Request-Method': 'POST'})
-        self.assertEqual(resp.headers['Access-Control-Allow-Origin'], '*')
-
     def test_origin_is_not_wildcard_if_allow_credentials(self):
         resp = self.app.options(
             '/cors_klass',
@@ -244,7 +235,6 @@ class TestCORS(TestCase):
             headers={
                 'Origin': 'lolnet.org',
                 'Access-Control-Request-Method': 'POST',
-                'Access-Control-Allow-Credentials': 'true'
             })
         self.assertEqual(resp.headers['Access-Control-Allow-Origin'],
                          'lolnet.org')


### PR DESCRIPTION
As per my submission of #319, I was hitting  CORS issue when using credentials.  In particular, I get the following error:

> XMLHttpRequest cannot load '....' A wildcard '*' cannot be used in the 'Access-Control- Allow-Origin' header when the credentials flag is true. Origin '....' is therefore not allowed access.

What I think should be happening is the server should be setting the 'Access-Control-Allow-Origin' response header to the origin provided in the credentialed request. I've replaced an incorrect check of a request header, Access-Control-Allow-Credentials, which is really a response header with a correct test on the service definition.
