### PR TITLE
Our test failed because of mock package update

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps =
     coverage
     nose
     webtest
-    mock
+    mock<1.1.0
     colander
     Sphinx
     rxjson


### PR DESCRIPTION
Our py26 failed because mock packages drop py26 support in version 1.1.0. Add
version limit for mock package in py26 environment in tox.ini.

PS Looks like in next version(after 1.1.3) they will restore py26 support.