### PR TITLE
Fix Access-Control-Max-Age value if undefined on service

### DIFF
--- a/cornice/service.py
+++ b/cornice/service.py
@@ -508,11 +508,15 @@ class Service(object):
         return False
 
     def cors_max_age_for(self, method=None):
+        max_age = None
         for meth, view, args in self.definitions:
             if method and meth.upper() == method.upper():
-                return args.get('cors_max_age', False)
+                max_age = args.get('cors_max_age', None)
+                break
 
-        return getattr(self, 'cors_max_age', None)
+        if max_age is None:
+            max_age = getattr(self, 'cors_max_age', None)
+        return max_age
 
 
 def decorate_view(view, args, method):

--- a/cornice/tests/test_service.py
+++ b/cornice/tests/test_service.py
@@ -460,6 +460,11 @@ class TestService(TestCase):
         foo.add_view('GET', _stub, cors_credentials=False)
         self.assertFalse(foo.cors_support_credentials_for('GET'))
 
+    def test_max_age_is_none_if_undefined(self):
+        foo = Service(name='foo', path='/foo')
+        foo.add_view('POST', _stub)
+        self.assertIsNone(foo.cors_max_age_for('POST'))
+
     def test_max_age_can_be_defined(self):
         foo = Service(name='foo', path='/foo', cors_max_age=42)
         foo.add_view('POST', _stub)


### PR DESCRIPTION
Otherwise the header is always present a `False` value.