### PR TITLE
String validators rendered as str.__doc__ in sphinxext

### DIFF
--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -121,7 +121,6 @@ class ServiceDirective(Directive):
             service_node += rst2node(trim(service.description))
 
         for method, view, args in service.definitions:
-
             if method == 'HEAD':
                 # Skip head - this is essentially duplicating the get docs.
                 continue

--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -167,7 +167,7 @@ class ServiceDirective(Directive):
                 method_node += attrs_node
 
             for validator in args.get('validators', ()):
-                ob = args['klass']
+                ob = args.get('klass')
                 if is_string(validator) and ob is not None:
                     validator = getattr(ob, validator)
                 if validator.__doc__ is not None:

--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -100,10 +100,13 @@ class ServiceDirective(Directive):
     def _resolve_obj_to_docstring(self, obj, args):
         # Resolve a view or validator to an object if type string
         # and return docstring.
-        if is_string(obj) and 'klass' in args:
-            ob = args['klass']
-            obj_ = getattr(ob, obj.lower())
-            return format_docstring(obj_)
+        if is_string(obj):
+            if 'klass' in args:
+                ob = args['klass']
+                obj_ = getattr(ob, obj.lower())
+                return format_docstring(obj_)
+            else:
+                return ''
         else:
             return format_docstring(obj)
 

--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -97,6 +97,16 @@ class ServiceDirective(Directive):
 
         return [self._render_service(s) for s in services]
 
+    def _resolve_obj_to_docstring(self, obj, args):
+        # Resolve a view or validator to an object if type string
+        # and return docstring.
+        if is_string(obj) and 'klass' in args:
+            ob = args['klass']
+            obj_ = getattr(ob, obj.lower())
+            return format_docstring(obj_)
+        else:
+            return format_docstring(obj)
+
     def _render_service(self, service):
         service_id = "service-%d" % self.env.new_serialno('service')
         service_node = nodes.section(ids=[service_id])
@@ -108,6 +118,7 @@ class ServiceDirective(Directive):
             service_node += rst2node(trim(service.description))
 
         for method, view, args in service.definitions:
+
             if method == 'HEAD':
                 # Skip head - this is essentially duplicating the get docs.
                 continue
@@ -115,13 +126,7 @@ class ServiceDirective(Directive):
             method_node = nodes.section(ids=[method_id])
             method_node += nodes.title(text=method)
 
-            if is_string(view):
-                if 'klass' in args:
-                    ob = args['klass']
-                    view_ = getattr(ob, view.lower())
-                    docstring = trim(view_.__doc__ or "") + '\n'
-            else:
-                docstring = trim(view.__doc__ or "") + '\n'
+            docstring = self._resolve_obj_to_docstring(view, args)
 
             if 'schema' in args:
                 schema = args['schema']
@@ -167,11 +172,7 @@ class ServiceDirective(Directive):
                 method_node += attrs_node
 
             for validator in args.get('validators', ()):
-                ob = args.get('klass')
-                if is_string(validator) and ob is not None:
-                    validator = getattr(ob, validator)
-                if validator.__doc__ is not None:
-                    docstring += trim(validator.__doc__)
+                docstring += self._resolve_obj_to_docstring(validator, args)
 
             if 'accept' in args:
                 accept = to_list(args['accept'])
@@ -206,11 +207,14 @@ class ServiceDirective(Directive):
             method_node += response
 
             service_node += method_node
-
         return service_node
 
 
 # Utils
+
+def format_docstring(obj):
+    """Return trimmed docstring with newline from object."""
+    return trim(obj.__doc__ or "") + '\n'
 
 
 def trim(docstring):

--- a/cornice/ext/sphinxext.py
+++ b/cornice/ext/sphinxext.py
@@ -167,6 +167,9 @@ class ServiceDirective(Directive):
                 method_node += attrs_node
 
             for validator in args.get('validators', ()):
+                ob = args['klass']
+                if is_string(validator) and ob is not None:
+                    validator = getattr(ob, validator)
                 if validator.__doc__ is not None:
                     docstring += trim(validator.__doc__)
 

--- a/cornice/tests/ext/dummy/views.py
+++ b/cornice/tests/ext/dummy/views.py
@@ -22,9 +22,14 @@ def get_info(request):
     return _USERS[username]
 
 
+def validate(request):
+    return request
+
+
 def includeme(config):
     # FIXME this should also work in includeme
-    user_info = Service(name='users', path='/{username}/info')
+    user_info = Service(name='users', path='/{username}/info',
+                        validators=('validate'))
     user_info.add_view('get', get_info)
     config.add_cornice_service(user_info)
 

--- a/cornice/tests/ext/dummy/views.py
+++ b/cornice/tests/ext/dummy/views.py
@@ -12,17 +12,18 @@ class ThingImp(object):
         self.context = context
 
     def collection_get(self):
-        """returns yay"""
+        """Returns yay."""
         return 'yay'
 
 
 def get_info(request):
-    "returns the user data"
+    """Returns the user data."""
     username = request.matchdict['username']
     return _USERS[username]
 
 
 def validate(request):
+    """Dummy validation."""
     return request
 
 

--- a/cornice/tests/ext/test_sphinxext.py
+++ b/cornice/tests/ext/test_sphinxext.py
@@ -34,5 +34,16 @@ class TestServiceDirective(TestCase):
         directive.options['services'] = ['users', "thing_service"]
         ret = directive.run()
         self.assertEqual(len(ret), 2)
-        self.assertTrue('Users service at' in str(ret[0]))
-        self.assertTrue('Thing_Service service at ' in str(ret[1]))
+        self.assertIn('Users service at', str(ret[0]))
+        self.assertIn('Thing_Service service at ', str(ret[1]))
+
+    def test_string_validator_resolved(self):
+        # A validator defined as a string should be parsed as an obj.
+        param = mock.Mock()
+        param.document.settings.env.new_serialno.return_value = 1
+        directive = ServiceDirective(
+            'test', [], {}, [], 1, 1, 'test', param, 1)
+        directive.options['app'] = 'cornice.tests.ext.dummy'
+        directive.options['services'] = ['users', "thing_service"]
+        ret = directive.run()
+        self.assertNotIn("str(object='') -> string", str(ret[0]))

--- a/cornice/tests/ext/test_sphinxext.py
+++ b/cornice/tests/ext/test_sphinxext.py
@@ -42,6 +42,8 @@ class TestServiceDirective(TestCase):
         self.assertIn('Thing_Service service at ', str(ret[1]))
 
     def test_string_validator_resolved(self):
-        # A validator defined as a string should be parsed as an obj.
+        # A validator defined as a string should be parsed as an obj,
+        # ensuring the docstring contains validator.__doc__ rather
+        # than str.__doc__.
         ret = self.directive.run()
         self.assertNotIn("str(object='') -> string", str(ret[0]))

--- a/cornice/tests/ext/test_sphinxext.py
+++ b/cornice/tests/ext/test_sphinxext.py
@@ -18,6 +18,16 @@ class TestUtil(TestCase):
 
 class TestServiceDirective(TestCase):
 
+    def setUp(self):
+        super(TestServiceDirective, self).setUp()
+        param = mock.Mock()
+        param.document.settings.env.new_serialno.return_value = 1
+
+        self.directive = ServiceDirective(
+            'test', [], {}, [], 1, 1, 'test', param, 1)
+        self.directive.options['app'] = 'cornice.tests.ext.dummy'
+        self.directive.options['services'] = ['users', "thing_service"]
+
     def test_module_reload(self):
         directive = ServiceDirective(
             'test', [], {}, [], 1, 1, 'test', mock.Mock(), 1)
@@ -26,24 +36,12 @@ class TestServiceDirective(TestCase):
         self.assertEqual(ret, [])
 
     def test_dummy(self):
-        param = mock.Mock()
-        param.document.settings.env.new_serialno.return_value = 1
-        directive = ServiceDirective(
-            'test', [], {}, [], 1, 1, 'test', param, 1)
-        directive.options['app'] = 'cornice.tests.ext.dummy'
-        directive.options['services'] = ['users', "thing_service"]
-        ret = directive.run()
+        ret = self.directive.run()
         self.assertEqual(len(ret), 2)
         self.assertIn('Users service at', str(ret[0]))
         self.assertIn('Thing_Service service at ', str(ret[1]))
 
     def test_string_validator_resolved(self):
         # A validator defined as a string should be parsed as an obj.
-        param = mock.Mock()
-        param.document.settings.env.new_serialno.return_value = 1
-        directive = ServiceDirective(
-            'test', [], {}, [], 1, 1, 'test', param, 1)
-        directive.options['app'] = 'cornice.tests.ext.dummy'
-        directive.options['services'] = ['users', "thing_service"]
-        ret = directive.run()
+        ret = self.directive.run()
         self.assertNotIn("str(object='') -> string", str(ret[0]))

--- a/cornice/tests/ext/test_sphinxext.py
+++ b/cornice/tests/ext/test_sphinxext.py
@@ -29,10 +29,10 @@ class TestServiceDirective(TestCase):
         self.directive.options['services'] = ['users', "thing_service"]
 
     def test_module_reload(self):
-        directive = ServiceDirective(
-            'test', [], {}, [], 1, 1, 'test', mock.Mock(), 1)
-        directive.options['modules'] = ['cornice']
-        ret = directive.run()
+        self.directive.options['app'] = None
+        self.directive.options['services'] = None
+        self.directive.options['modules'] = ['cornice']
+        ret = self.directive.run()
         self.assertEqual(ret, [])
 
     def test_dummy(self):


### PR DESCRIPTION
Currently in sphinxext, validators defined as strings in a resource or service are rendered directly as `str.__doc__` e.g.

    user_info = Service(name='users', path='/{username}/info',
                        validators=('validate'))

will render:

    "str(object='') -> string\n\nReturn a nice string representation of the object.\nIf the argument is a string, the return value is the same object."

This branch provides a fix and a relevant test, type checking strings and ensuring the validator object's `__doc__` is rendered. String to object resolution, also required to render views, has been factored out to a new method, `_resolve_obj_to_docstring`.

This branch also contains some mostly cosmetic refactoring of the sphinext tests.