### PR TITLE
Convert None to null before calling deserialize

### DIFF
--- a/cornice/schemas.py
+++ b/cornice/schemas.py
@@ -143,6 +143,8 @@ def validate_colander_schema(schema, request):
                             serialized = original.getall(attr.name)
                         else:
                             serialized = data[attr.name]
+                        if serialized is None:
+                            serialized = null
                         deserialized = attr.deserialize(serialized)
                 except Invalid as e:
                     # the struct is invalid

--- a/cornice/tests/test_schemas.py
+++ b/cornice/tests/test_schemas.py
@@ -55,6 +55,10 @@ if COLANDER:
     class InheritedSchema(TestingSchema):
         foo = SchemaNode(Int(), missing=1)
 
+    class TestNoneSchema(MappingSchema):
+        foo = SchemaNode(String())
+        bar = SchemaNode(Sequence(), SchemaNode(String()), missing=None)
+
     class ToBoundSchema(TestingSchema):
         foo = SchemaNode(Int(), missing=1)
         bazinga = SchemaNode(String(), type='str', location="body",
@@ -232,6 +236,15 @@ if COLANDER:
 
             dummy_request = get_mock_request('{"bar": "some data"}')
             validate_colander_schema(schema, dummy_request)
+
+        def test_sequence_with_null(self):
+            # null can be passed to a sequence field
+            schema = CorniceSchema.from_colander(TestNoneSchema)
+
+            dummy_request = get_mock_request('{"foo": "abc", "bar": null}')
+            validate_colander_schema(schema, dummy_request)
+            self.assertEqual(len(dummy_request.errors), 0)
+            self.assertIsNone(dummy_request.validated['bar'])
 
         def test_colander_schema_using_drop(self):
             """


### PR DESCRIPTION
I have a schema like the following:

    class TestNoneSchema(MappingSchema):
        foo = SchemaNode(String())
        bar = SchemaNode(Sequence(), SchemaNode(String()), missing=None)

When I try to validate a JSON body where `bar` is `null` (for example `'{"foo": "abc", "bar": null}'`), the validation returns the following error:

     [{'name': 'bar', 'location': 'body', 'description': u'"None" is not iterable'}]

This is because Cornice calls `deserialize` in [validate_colander_schema](https://github.com/mozilla-services/cornice/blob/c71b5c4fb25c70a62b203c9480810ec8707878bf/cornice/schemas.py#L146) with `None` instead of `colander.null`. Because [Sequence.serialize](https://github.com/Pylons/colander/blob/master/colander/__init__.py#L1058-L1079) only checks for `colander.null`, an exception is thrown.

As far as I understand how Colander works, `deserialize` should in general not be called with `None` but `colander.null`. So, it would be the responsibility of Cornice to convert `None` to `null`.