### PR TITLE
Incorrect attribute 'validator' replaced with 'validators'

### DIFF
--- a/docs/source/testing.rst
+++ b/docs/source/testing.rst
@@ -20,7 +20,7 @@ Let's suppose you have this service definition::
             request.errors.add('body', 'paid', 'You must pay!')
 
 
-    @service.get(validator=has_payed)
+    @service.get(validators=has_payed)
     def get1(request):
         return {"test": "succeeded"}
 


### PR DESCRIPTION
This typo in [Testing example](https://cornice.readthedocs.org/en/latest/testing.html) caused pserve to fail with `pyramid.exceptions.ConfigurationError: Unknown predicate values: {'validator': <function has_payed at 0x7fb14c54f500>}`

