### PR TITLE
properly handle content_type callables returning a single internet media type as scalar

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ CHANGELOG
 ==================
 
 - Nothing changed yet.
+- Properly handle content_type callables returning a single internet media type as scalar (#343)
 
 
 1.2.0 (2016-01-18)

--- a/cornice/tests/validationapp.py
+++ b/cornice/tests/validationapp.py
@@ -62,11 +62,8 @@ def get2(request):
 service3 = Service(name="service3", path="/service3")
 
 
-def _accept(request):
-    return ('application/json', 'text/json')
-
-
-@service3.get(accept=_accept)
+@service3.get(accept=lambda request: ('application/json', 'text/json'))
+@service3.put(accept=lambda request: 'text/json')
 def get3(request):
     return {"body": "yay!"}
 
@@ -117,15 +114,13 @@ service5 = Service(name="service5", path="/service5")
 def post5(request):
     return "some response"
 
-# test the "content_type" parameter (callable)
+
+# service for testing the "content_type" parameter (callable)
 service6 = Service(name="service6", path="/service6")
 
 
-def _content_type(request):
-    return ('text/xml', 'application/json')
-
-
-@service6.post(content_type=_content_type)
+@service6.post(content_type=lambda request: ('text/xml', 'application/json'))
+@service6.put(content_type=lambda request: 'text/xml')
 def post6(request):
     return {"body": "yay!"}
 

--- a/cornice/util.py
+++ b/cornice/util.py
@@ -111,15 +111,15 @@ def match_accept_header(func, context, request):
         The callable returning the list of acceptable content-types,
         given a request. It should accept a "request" argument.
     """
-    acceptable = func(request)
     # attach the accepted egress content types to the request
+    acceptable = to_list(func(request))
     request.info['acceptable'] = acceptable
     return request.accept.best_match(acceptable) is not None
 
 
 def match_content_type_header(func, context, request):
-    supported_contenttypes = func(request)
     # attach the accepted ingress content types to the request
+    supported_contenttypes = to_list(func(request))
     request.info['supported_contenttypes'] = supported_contenttypes
     return content_type_matches(request, supported_contenttypes)
 


### PR DESCRIPTION
Improve and resolve #343, add appropriate tests.