### PR TITLE
Do not raise a 415 error when no content-type and no body

### DIFF
--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -219,8 +219,8 @@ def register_service_views(config, service):
         predicate_definitions = _pop_complex_predicates(args)
 
         if predicate_definitions:
-            extra_empty_ctype = [({'kind': 'content_type', 'value': ''},)]
-            for predicate_list in predicate_definitions + extra_empty_ctype:
+            empty_contenttype = [({'kind': 'content_type', 'value': ''},)]
+            for predicate_list in predicate_definitions + empty_contenttype:
                 args = dict(args)  # make a copy of the dict to not modify it
 
                 # prepare view args by evaluating complex predicates

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -219,7 +219,8 @@ def register_service_views(config, service):
         predicate_definitions = _pop_complex_predicates(args)
 
         if predicate_definitions:
-            for predicate_list in predicate_definitions:
+            extra_empty_ctype = [({'kind': 'content_type', 'value': ''},)]
+            for predicate_list in predicate_definitions + extra_empty_ctype:
                 args = dict(args)  # make a copy of the dict to not modify it
 
                 # prepare view args by evaluating complex predicates

--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -208,7 +208,9 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
 
         # requesting without a Content-Type header nor a body should
         # return a 200.
-        app.post('/service5', status=200)
+        request = app.RequestClass.blank('/service5', method='POST')
+        response = app.do_request(request, 200, True)
+        self.assertEqual(response.status_code, 200)
 
     def test_content_type_wrong_single(self):
         # Tests that the Content-Type request header satisfies the requirement.

--- a/cornice/tests/test_validation.py
+++ b/cornice/tests/test_validation.py
@@ -189,8 +189,10 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
 
         # Requesting without a Content-Type header should
         # return "415 Unsupported Media Type" ...
-        request = app.RequestClass.blank('/service5', method='POST')
+        request = app.RequestClass.blank('/service5', method='POST',
+                                         POST="some data")
         response = app.do_request(request, 415, True)
+        self.assertEqual(response.status_code, 415)
 
         # ... with an appropriate json error structure.
         error_location = response.json['errors'][0]['location']
@@ -199,6 +201,14 @@ class TestServiceDefinition(LoggingCatcher, TestCase):
         self.assertEqual('header', error_location)
         self.assertEqual('Content-Type', error_name)
         self.assertIn('application/json', error_description)
+
+    def test_content_type_missing_with_no_body_should_pass(self):
+        # test that a Content-Type request headers is present
+        app = TestApp(main({}))
+
+        # requesting without a Content-Type header nor a body should
+        # return a 200.
+        app.post('/service5', status=200)
 
     def test_content_type_wrong_single(self):
         # Tests that the Content-Type request header satisfies the requirement.


### PR DESCRIPTION
Return a 415 error response, if and only if there is some content.

@almet r?