### PR TITLE
Remove request from errors list (fixes #328)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,7 @@ CHANGELOG
 Breaking changes
 
 - Get rid of Buildout files (#369)
+- Errors list ``request.errors`` has no ``request`` anymore (fixes #328)
 
 
 1.2.1 (2016-03-15)

--- a/cornice/errors.py
+++ b/cornice/errors.py
@@ -10,8 +10,7 @@ except ImportError:
 class Errors(list):
     """Holds Request errors
     """
-    def __init__(self, request=None, status=400):
-        self.request = request
+    def __init__(self, status=400):
         self.status = status
         super(Errors, self).__init__()
 

--- a/cornice/pyramidhook.py
+++ b/cornice/pyramidhook.py
@@ -139,7 +139,7 @@ def wrap_request(event):
         setattr(request, 'validated', {})
 
     if not hasattr(request, 'errors'):
-        setattr(request, 'errors', Errors(request))
+        setattr(request, 'errors', Errors())
 
     if not hasattr(request, 'info'):
         setattr(request, 'info', {})


### PR DESCRIPTION
The errors list is accessed via ``request.errors``, it makes thus no sense to store a circular reference.

And «Look mum, no tests fail!» (*ie. no spec was changed*)

@Natim r?